### PR TITLE
Added device_class for the applicable sensors.

### DIFF
--- a/custom_components/marstek/sensor.py
+++ b/custom_components/marstek/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -129,6 +129,7 @@ class MarstekBatterySensor(MarstekSensor):
     """Representation of a Marstek battery sensor."""
 
     _attr_translation_key = "battery_level"
+    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:battery"
@@ -153,6 +154,7 @@ class MarstekBatterySensor(MarstekSensor):
 class MarstekPowerSensor(MarstekSensor):
     """Representation of a Marstek power sensor."""
 
+    _attr_device_class = SensorDeviceClass.POWER
     _attr_native_unit_of_measurement = UnitOfPower.WATT
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:flash"
@@ -294,12 +296,15 @@ class MarstekPVSensor(MarstekSensor):
         self._metric_type = metric_type
 
         if metric_type == "power":
+            self._attr_device_class = SensorDeviceClass.POWER
             self._attr_native_unit_of_measurement = UnitOfPower.WATT
             self._attr_icon = "mdi:solar-power"
         elif metric_type == "voltage":
+            self._attr_device_class = SensorDeviceClass.VOLTAGE
             self._attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
             self._attr_icon = "mdi:flash"
         elif metric_type == "current":
+            self._attr_device_class = SensorDeviceClass.CURRENT
             self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
             self._attr_icon = "mdi:current-ac"
         elif metric_type == "state":


### PR DESCRIPTION
## Add `device_class` to Marstek sensors

Previously, the Marstek sensors did not specify a `device_class`, which meant Home Assistant could not automatically categorize them or offer features like unit conversion, long-term statistics, or energy dashboard integration.

The following `device_class` attributes were added:

| Sensor | Unit | `device_class` |
|---|---|---|
| Battery SOC | % | `battery` |
| Grid Power | W | `power` |
| PV Power (×4 channels) | W | `power` |
| PV Voltage (×4 channels) | V | `voltage` |
| PV Current (×4 channels) | A | `current` |

Diagnostic sensors (device IP, version, MAC addresses) and status sensors (device mode, battery status) remain without a `device_class`, as they represent non-numeric information.
